### PR TITLE
Updates logic due to removal of the "objects_list" dictionary in the original patch script

### DIFF
--- a/extract.nix
+++ b/extract.nix
@@ -27,17 +27,9 @@ stdenv.mkDerivation rec {
     patch -p1 < ${./extract-patch-list.diff}
     bash patch.sh > patch-list.json
 
-    cp ${src}/patch.sh patch.sh
-    patch -p1 < ${./extract-object-list.diff}
-    bash patch.sh > object-list.json
-
     cp ${src}/patch-fbc.sh patch.sh
     patch -p1 < ${./extract-patch-list.diff}
     bash patch.sh > fbc-patch-list.json
-
-    cp ${src}/patch-fbc.sh patch.sh
-    patch -p1 < ${./extract-object-list.diff}
-    bash patch.sh > fbc-object-list.json
   '';
 
   installPhase = ''

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674902473,
-        "narHash": "sha256-MdKJeeDTjCtmoVPWLEDg10jgknt6rqTO3c1WeNQtho4=",
-        "owner": "NixOS",
+        "lastModified": 1702780907,
+        "narHash": "sha256-blbrBBXjjZt6OKTcYX1jpe9SRof2P9ZYWPzq22tzXAA=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "548896f4d9f7db2f7205d82727d6c03c86d2f896",
+        "rev": "1e2e384c5b7c50dbf8e9c441a9e58d85f408b01f",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "release-22.11",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "nixpkgs/release-23.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
   };
 
   outputs = {
@@ -34,14 +34,20 @@
               ...
             }: let
               patchList = importJSON "${jsons}/${prefix}patch-list.json";
-              objectList = importJSON "${jsons}/${prefix}object-list.json";
               patch = patchList.${version};
-              object = objectList.${version};
             in {
               preFixup =
                 preFixup
                 + ''
-                  sed -i '${patch}' $out/lib/${object}.${version}
+                  version=${version}
+                  driver_maj_version=''${version%%.*}
+                  if [[ $driver_maj_version -ge "415" && $driver_maj_version -le "435" ]]; then
+                      object='libnvcuvid.so'
+                  else
+                      object='libnvidia-encode.so'
+                  fi
+
+                  sed -i '${patch}' $out/lib/''${object}.''${version}
                 '';
             });
         in {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "nixpkgs/release-23.05";
   };
 
   outputs = {
@@ -35,19 +35,12 @@
             }: let
               patchList = importJSON "${jsons}/${prefix}patch-list.json";
               patch = patchList.${version};
+              object = "libnvidia-encode.so";
             in {
               preFixup =
                 preFixup
                 + ''
-                  version=${version}
-                  driver_maj_version=''${version%%.*}
-                  if [[ $driver_maj_version -ge "415" && $driver_maj_version -le "435" ]]; then
-                      object='libnvcuvid.so'
-                  else
-                      object='libnvidia-encode.so'
-                  fi
-
-                  sed -i '${patch}' $out/lib/''${object}.''${version}
+                  sed -i '${patch}' $out/lib/${object}.${version}
                 '';
             });
         in {


### PR DESCRIPTION
I've tested it and it works on my system, would be great to have more people to test it.
The original script recently removed the "objects_list" dictionary and replaced with a quick "if" based on the version of the Nvidia Driver. The result can be either "libnvcuvid.so" or "libnvidia-encode.so".
I'm really new to Nix so I wasn't able to come up with a solution to determine the "object" automatically based on the driver version ([this is how it's done on the original script](https://github.com/keylase/nvidia-patch/blob/master/patch.sh#L288-L294)), so help on that would be awesome! (And pretty quick and easy for any experienced Nix user)