### PR TITLE
run auto-update weekly using GH cron

### DIFF
--- a/.github/workflows/extract.yaml
+++ b/.github/workflows/extract.yaml
@@ -6,6 +6,8 @@ on:
       - 'main'
   repository_dispatch:
     types: [ build ]
+  schedule:
+    - cron: '33 3 * * 1'
 
 jobs:
   extract:


### PR DESCRIPTION
Runs 3:33 every Monday.

I have confirmed that `devops-infra/action-commit-push` will not fail if there are no changes: https://github.com/devops-infra/action-commit-push/blob/8bc2ff9f9de7aa2a7581fc7e5b6401c04cab54c7/entrypoint.sh#L39

Cron expansion: https://crontab.guru/#33_3_*_*_1

GH actions doc: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onschedule