### PR TITLE
fix: flake eval

### DIFF
--- a/extractor.nix
+++ b/extractor.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   writeShellApplication,
   jq,
 }:

--- a/flake.nix
+++ b/flake.nix
@@ -17,10 +17,10 @@
         inherit system overlays;
         config.allowUnfreePredicate = pkg: true;
       };
-    in rec {
-      packages = rec {
-        inherit (pkgs) nvidia-patch-extractor nvidia-patch nvidia-patch-list;
-        nvidia-patched = nvidia-patch.patch-nvenc (nvidia-patch.patch-fbc pkgs.linuxPackages.nvidiaPackages.stable);
+    in {
+      packages = {
+        inherit (pkgs) nvidia-patch-extractor;
+        nvidia-patched = pkgs.nvidia-patch.patch-nvenc (pkgs.nvidia-patch.patch-fbc pkgs.linuxPackages.nvidiaPackages.stable);
       };
       devShell = pkgs.mkShell {
         nativeBuildInputs = with pkgs; [jq patch];


### PR DESCRIPTION
Fixes the following error:

```
> nix flake show path:. -v
evaluating ''...
path:/home/nikara/git/nvidia-patch-nixos?lastModified=1770040706&narHash=sha256-tfiZlT36UcijAdD3nlBglRxFTKFZr0JzGmh2cztF5CY%3D
evaluating 'devShell'...
├───devShell
evaluating 'devShell.aarch64-darwin'...
│   ├───aarch64-darwin omitted (use '--all-systems' to show)
evaluating 'devShell.aarch64-linux'...
│   ├───aarch64-linux omitted (use '--all-systems' to show)
evaluating 'devShell.x86_64-darwin'...
│   ├───x86_64-darwin omitted (use '--all-systems' to show)
evaluating 'devShell.x86_64-linux'...
│   └───x86_64-linux: development environment 'nix-shell'
evaluating 'overlays'...
├───overlays
evaluating 'overlays.default'...
│   └───default: Nixpkgs overlay
evaluating 'packages'...
└───packages
evaluating 'packages.aarch64-darwin'...
    ├───aarch64-darwin
evaluating 'packages.aarch64-darwin.nvidia-patch'...
    │   ├───nvidia-patch omitted (use '--all-systems' to show)
evaluating 'packages.aarch64-darwin.nvidia-patch-extractor'...
    │   ├───nvidia-patch-extractor omitted (use '--all-systems' to show)
evaluating 'packages.aarch64-darwin.nvidia-patch-list'...
    │   ├───nvidia-patch-list omitted (use '--all-systems' to show)
evaluating 'packages.aarch64-darwin.nvidia-patched'...
    │   └───nvidia-patched omitted (use '--all-systems' to show)
evaluating 'packages.aarch64-linux'...
    ├───aarch64-linux
evaluating 'packages.aarch64-linux.nvidia-patch'...
    │   ├───nvidia-patch omitted (use '--all-systems' to show)
evaluating 'packages.aarch64-linux.nvidia-patch-extractor'...
    │   ├───nvidia-patch-extractor omitted (use '--all-systems' to show)
evaluating 'packages.aarch64-linux.nvidia-patch-list'...
    │   ├───nvidia-patch-list omitted (use '--all-systems' to show)
evaluating 'packages.aarch64-linux.nvidia-patched'...
    │   └───nvidia-patched omitted (use '--all-systems' to show)
evaluating 'packages.x86_64-darwin'...
    ├───x86_64-darwin
evaluating 'packages.x86_64-darwin.nvidia-patch'...
    │   ├───nvidia-patch omitted (use '--all-systems' to show)
evaluating 'packages.x86_64-darwin.nvidia-patch-extractor'...
    │   ├───nvidia-patch-extractor omitted (use '--all-systems' to show)
evaluating 'packages.x86_64-darwin.nvidia-patch-list'...
    │   ├───nvidia-patch-list omitted (use '--all-systems' to show)
evaluating 'packages.x86_64-darwin.nvidia-patched'...
    │   └───nvidia-patched omitted (use '--all-systems' to show)
evaluating 'packages.x86_64-linux'...
    └───x86_64-linux
evaluating 'packages.x86_64-linux.nvidia-patch'...
error: expected a derivation
```